### PR TITLE
add value attribute

### DIFF
--- a/src/DateDropdown.vue
+++ b/src/DateDropdown.vue
@@ -22,7 +22,7 @@
 		<!-- Year -->
 		<div :class="[selectWrapperClassName]">
 			<select v-model="selectedYear" @change="updateDays()" :class="[selectClassName, selectYearClassName]">
-				<option v-for="year in years" :key="year.year" :value="day.day">
+				<option v-for="year in years" :key="year.year" :value="year.year">
 					{{ year.year }}
 				</option>
 			</select>

--- a/src/DateDropdown.vue
+++ b/src/DateDropdown.vue
@@ -4,7 +4,7 @@
 		<!-- Day -->
 		<div :class="[selectWrapperClassName]">
 			<select v-model="selectedDay" :class="[selectClassName, selectDayClassName]">
-				<option v-for="day in days" :key="day.day">
+				<option v-for="day in days" :key="day.day" :value="day.day">
 					{{ day.day }}
 				</option>
 			</select>
@@ -22,7 +22,7 @@
 		<!-- Year -->
 		<div :class="[selectWrapperClassName]">
 			<select v-model="selectedYear" @change="updateDays()" :class="[selectClassName, selectYearClassName]">
-				<option v-for="year in years" :key="year.year">
+				<option v-for="year in years" :key="year.year" :value="day.day">
 					{{ year.year }}
 				</option>
 			</select>


### PR DESCRIPTION
this fixes up an issue with IE and the drop down. Without the value attribute, the date seems to be malformed. There are prepended spaces with the date in IE. Works fine in other browsers.

Also the defaults values seem to not work on IE without this change